### PR TITLE
Parse translated states

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,23 @@
 PATH
   remote: .
   specs:
-    tc211-termbase (0.1.0)
+    tc211-termbase (0.1.1)
       creek
       iso-639
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    creek (2.4.1)
-      http (~> 3.0)
+    creek (2.4.4)
+      http (~> 4.0)
       nokogiri (>= 1.7.0)
       rubyzip (>= 1.0.0)
     diff-lcs (1.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    http (3.3.0)
+    http (4.1.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.0)
@@ -27,10 +27,10 @@ GEM
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
     iso-639 (0.2.8)
-    mini_portile2 (2.3.0)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
-    public_suffix (3.0.3)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
+    public_suffix (3.1.0)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -38,17 +38,17 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubyzip (1.2.2)
+    rubyzip (1.2.3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
 
 PLATFORMS
   ruby
@@ -60,4 +60,4 @@ DEPENDENCIES
   tc211-termbase!
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/lib/tc211/termbase/term.rb
+++ b/lib/tc211/termbase/term.rb
@@ -35,6 +35,7 @@ class Term
     # puts "options #{options.inspect}"
 
     options.each_pair do |k, v|
+      v = v.strip if v.is_a?(String)
       next unless v
       case k
       when /^example/
@@ -64,8 +65,15 @@ class Term
   # entry-status
   ## Must be one of notValid valid superseded retired
   def entry_status=(value)
-    unless %w(notValid valid superseded retired).include?(value)
-      value = "notValid"
+    case value
+    when "有效的", "käytössä", "действующий", "válido"
+      value = "valid"
+    when "korvattu", "reemplazado"
+      value = "superseded"
+    when "информация отсутствует" # "information absent"!?
+      value = "retired"
+    when %w(notValid valid superseded retired)
+      # do nothing
     end
     @entry_status = value
   end
@@ -73,8 +81,15 @@ class Term
   # classification
   ## Must be one of the following: preferred admitted deprecated
   def classification=(value)
-    unless %w(preferred admitted deprecated).include?(value)
+    case value
+    when ""
+      value = "admitted"
+    when "认可的", "допустимый", "admitido"
+      value = "admitted"
+    when "首选的", "suositettava", "suositeltava", "рекомендуемый", "preferente"
       value = "preferred"
+    when %w(preferred admitted deprecated)
+      # do nothing
     end
     @classification = value
   end

--- a/lib/tc211/termbase/terms_section.rb
+++ b/lib/tc211/termbase/terms_section.rb
@@ -18,11 +18,14 @@ class TermsSection < SheetSection
   TERM_BODY_COLUMN_MAP = {
     "Term_ID" => "id",
     "Term" => "term",
-    "Term [OPERATING LANGUAGE]" => "term",
-    "Term_Abbreviation" => "abbrev",
+    "Term .OPERATING LANGUAGE." => "term",
+    # In the English sheet, column is named "Term Abbreviation"
+    "Term Abbreviation" => "abbrev",
+    # In other sheets, column named "Term_Abbreviation"
+    "Term_Abbreviation .OPERATING LANGUAGE." => "abbrev",
     "Country code" => "country-code",
     "Definition" => "definition",
-    "Term [OPERATING LANGUAGE - ALTERNATIVE CHARACTER SET]" => "alt",
+    "Term .OPERATING LANGUAGE - ALTERNATIVE CHARACTER SET." => "alt",
     "Term in English" => nil,
     "Entry Status" => "entry-status",
     ## Must be one of 'notValid' 'valid' 'superseded' 'retired'

--- a/lib/tc211/termbase/version.rb
+++ b/lib/tc211/termbase/version.rb
@@ -1,5 +1,5 @@
 module Tc211
   module Termbase
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
As described in https://github.com/ISO-TC211/TMG/issues/1 , some status codes are translated in Spanish, Russian, Chinese and Finnish. This enhancement parses those accordingly.

NOTE: The uncertainly of mapped terms in https://github.com/ISO-TC211/TMG/issues/1 still apply.