### PR TITLE
updated to use glossarist models for concept and managed_concept

### DIFF
--- a/lib/tc211/termbase.rb
+++ b/lib/tc211/termbase.rb
@@ -12,8 +12,15 @@ module Tc211
     ::Glossarist.configure do |config|
       config.register_extension_attributes(["authoritativeSource"])
 
-      config.register_class(:localized_concept, Tc211::Termbase::Glossarist::Concept)
-      config.register_class(:managed_concept, Tc211::Termbase::Glossarist::ManagedConcept)
+      config.register_class(
+        :localized_concept,
+        Tc211::Termbase::Glossarist::Concept,
+      )
+
+      config.register_class(
+        :managed_concept,
+        Tc211::Termbase::Glossarist::ManagedConcept,
+      )
     end
   end
 end

--- a/lib/tc211/termbase.rb
+++ b/lib/tc211/termbase.rb
@@ -1,10 +1,20 @@
 require "glossarist"
 require "tc211/termbase/version"
 
+require_relative "termbase/glossarist/concept"
+require_relative "termbase/glossarist/managed_concept"
+
 module Tc211
   module Termbase
     class Error < StandardError; end
+
     # Your code goes here...
+    ::Glossarist.configure do |config|
+      config.register_extension_attributes(["authoritativeSource"])
+
+      config.register_class(:localized_concept, Tc211::Termbase::Glossarist::Concept)
+      config.register_class(:managed_concept, Tc211::Termbase::Glossarist::ManagedConcept)
+    end
   end
 end
 

--- a/lib/tc211/termbase/concept.rb
+++ b/lib/tc211/termbase/concept.rb
@@ -59,7 +59,9 @@ module Tc211::Termbase
     end
 
     def to_glossarist_concept
-      concept = Tc211::Termbase::Glossarist::ManagedConcept.new(data: { id: id.to_s })
+      concept = Tc211::Termbase::Glossarist::ManagedConcept.new(
+        data: { id: id.to_s },
+      )
 
       localized_concepts = []
 

--- a/lib/tc211/termbase/concept.rb
+++ b/lib/tc211/termbase/concept.rb
@@ -59,7 +59,7 @@ module Tc211::Termbase
     end
 
     def to_glossarist_concept
-      concept = Glossarist::ManagedConcept.new(data: { id: id.to_s })
+      concept = Tc211::Termbase::Glossarist::ManagedConcept.new(data: { id: id.to_s })
 
       localized_concepts = []
 

--- a/lib/tc211/termbase/concept_collection.rb
+++ b/lib/tc211/termbase/concept_collection.rb
@@ -26,7 +26,7 @@ module Tc211::Termbase
     end
 
     def to_concept_collection
-      collection = Glossarist::ManagedConceptCollection.new
+      collection = ::Glossarist::ManagedConceptCollection.new
 
       values.each do |term_concept|
         next if term_concept.nil?

--- a/lib/tc211/termbase/glossarist/concept.rb
+++ b/lib/tc211/termbase/glossarist/concept.rb
@@ -1,0 +1,27 @@
+module Tc211::Termbase
+  module Glossarist
+    class Concept < ::Glossarist::LocalizedConcept
+      attr_accessor :status, :dateAccepted
+
+      def uuid
+        @uuid ||= ::Glossarist::Utilities::UUID.uuid_v5(
+          ::Glossarist::Utilities::UUID::OID_NAMESPACE,
+          to_h(only_data: true).to_yaml,
+        )
+      end
+
+      def to_h(only_data: false)
+        date_accepted = dates.find(&:accepted?)
+
+        data_hash = super()
+        return data_hash if only_data
+
+        data_hash.merge({
+          "dateAccepted" => date_accepted&.date&.dup,
+          "id" => uuid,
+          "status" => entry_status,
+        }.compact)
+      end
+    end
+  end
+end

--- a/lib/tc211/termbase/glossarist/concept.rb
+++ b/lib/tc211/termbase/glossarist/concept.rb
@@ -1,26 +1,32 @@
-module Tc211::Termbase
-  module Glossarist
-    class Concept < ::Glossarist::LocalizedConcept
-      attr_accessor :status, :dateAccepted
+module Tc211
+  module Termbase
+    module Glossarist
+      class Concept < ::Glossarist::LocalizedConcept
+        attr_accessor :status, :dateAccepted
 
-      def uuid
-        @uuid ||= ::Glossarist::Utilities::UUID.uuid_v5(
-          ::Glossarist::Utilities::UUID::OID_NAMESPACE,
-          to_h(only_data: true).to_yaml,
-        )
-      end
+        def uuid
+          @uuid ||= ::Glossarist::Utilities::UUID.uuid_v5(
+            ::Glossarist::Utilities::UUID::OID_NAMESPACE,
+            to_h(only_data: true).to_yaml,
+          )
+        end
 
-      def to_h(only_data: false)
-        date_accepted = dates.find(&:accepted?)
+        def to_h(only_data: false)
+          data_hash = super()
+          return data_hash if only_data
 
-        data_hash = super()
-        return data_hash if only_data
+          data_hash.merge(register_info)
+        end
 
-        data_hash.merge({
-          "dateAccepted" => date_accepted&.date&.dup,
-          "id" => uuid,
-          "status" => entry_status,
-        }.compact)
+        def register_info
+          date_accepted = dates.find(&:accepted?)
+
+          {
+            "dateAccepted" => date_accepted&.date&.dup,
+            "id" => uuid,
+            "status" => entry_status,
+          }.compact
+        end
       end
     end
   end

--- a/lib/tc211/termbase/glossarist/managed_concept.rb
+++ b/lib/tc211/termbase/glossarist/managed_concept.rb
@@ -1,26 +1,33 @@
-module Tc211::Termbase
-  module Glossarist
-    class ManagedConcept < ::Glossarist::ManagedConcept
-      attr_accessor :status
+module Tc211
+  module Termbase
+    module Glossarist
+      class ManagedConcept < ::Glossarist::ManagedConcept
+        attr_accessor :status
 
-      def uuid
-        @uuid ||= ::Glossarist::Utilities::UUID.uuid_v5(
-          ::Glossarist::Utilities::UUID::OID_NAMESPACE,
-          to_h(only_data: true).to_yaml,
-        )
-      end
+        def uuid
+          @uuid ||= ::Glossarist::Utilities::UUID.uuid_v5(
+            ::Glossarist::Utilities::UUID::OID_NAMESPACE,
+            to_h(only_data: true).to_yaml,
+          )
+        end
 
-      def to_h(only_data: false)
-        data_hash = super()
-        return data_hash if only_data
+        def to_h(only_data: false)
+          data_hash = super()
+          return data_hash if only_data
 
-        date_accepted = default_lang.dates.find(&:accepted?)
-        data_hash.merge({
-          "dateAccepted" => date_accepted&.date&.dup,
-          "id" => uuid,
-          "related" => related&.map(&:to_h) || [],
-          "status" => default_lang.entry_status,
-        }.compact)
+          data_hash.merge(register_info)
+        end
+
+        def register_info
+          date_accepted = default_lang.dates.find(&:accepted?)
+
+          {
+            "dateAccepted" => date_accepted&.date&.dup,
+            "id" => uuid,
+            "related" => related&.map(&:to_h) || [],
+            "status" => default_lang.entry_status,
+          }.compact
+        end
       end
     end
   end

--- a/lib/tc211/termbase/glossarist/managed_concept.rb
+++ b/lib/tc211/termbase/glossarist/managed_concept.rb
@@ -1,0 +1,27 @@
+module Tc211::Termbase
+  module Glossarist
+    class ManagedConcept < ::Glossarist::ManagedConcept
+      attr_accessor :status
+
+      def uuid
+        @uuid ||= ::Glossarist::Utilities::UUID.uuid_v5(
+          ::Glossarist::Utilities::UUID::OID_NAMESPACE,
+          to_h(only_data: true).to_yaml,
+        )
+      end
+
+      def to_h(only_data: false)
+        data_hash = super()
+        return data_hash if only_data
+
+        date_accepted = default_lang.dates.find(&:accepted?)
+        data_hash.merge({
+          "dateAccepted" => date_accepted&.date&.dup,
+          "id" => uuid,
+          "related" => related&.map(&:to_h) || [],
+          "status" => default_lang.entry_status,
+        }.compact)
+      end
+    end
+  end
+end

--- a/lib/tc211/termbase/term.rb
+++ b/lib/tc211/termbase/term.rb
@@ -342,7 +342,9 @@ module Tc211::Termbase
     def authoritative_source_array
       return unless authoritative_source
 
-      [ "link" => authoritative_source["link"] ]
+      [
+        "link" => authoritative_source["link"],
+      ]
     end
 
     def lineage_source_hash
@@ -358,7 +360,7 @@ module Tc211::Termbase
     end
 
     def to_localized_concept_hash
-      localized_concept_hash = to_hash
+      concept_hash = to_hash
 
       %w[
         review_status
@@ -371,15 +373,17 @@ module Tc211::Termbase
         lineage_source_similarity
         country_code
       ].each do |key|
-        localized_concept_hash.delete(key)
+        concept_hash.delete(key)
       end
 
-      localized_concept_hash["id"] = localized_concept_hash["id"].to_s
-      localized_concept_hash["sources"] = sources_hash
+      concept_hash["id"] = concept_hash["id"].to_s
+      concept_hash["sources"] = sources_hash
 
-      localized_concept_hash["authoritativeSource"] = authoritative_source_array if authoritative_source_array
+      if authoritative_source_array
+        concept_hash["authoritativeSource"] = authoritative_source_array
+      end
 
-      localized_concept_hash
+      concept_hash
     end
   end
 end

--- a/lib/tc211/termbase/term.rb
+++ b/lib/tc211/termbase/term.rb
@@ -339,6 +339,12 @@ module Tc211::Termbase
       }
     end
 
+    def authoritative_source_array
+      return unless authoritative_source
+
+      [ "link" => authoritative_source["link"] ]
+    end
+
     def lineage_source_hash
       return unless lineage_source
 
@@ -370,6 +376,8 @@ module Tc211::Termbase
 
       localized_concept_hash["id"] = localized_concept_hash["id"].to_s
       localized_concept_hash["sources"] = sources_hash
+
+      localized_concept_hash["authoritativeSource"] = authoritative_source_array if authoritative_source_array
 
       localized_concept_hash
     end

--- a/spec/tc211/termbase_spec.rb
+++ b/spec/tc211/termbase_spec.rb
@@ -1,3 +1,5 @@
+require "pry"
+
 RSpec.describe Tc211::Termbase do
   it "has a version number" do
     expect(Tc211::Termbase::VERSION).not_to be nil
@@ -116,6 +118,9 @@ RSpec.describe Tc211::Termbase do
                     "status" => "identical",
                   },
                 ],
+                "authoritativeSource" => [
+                  { "link"=>"https://www.iso.org/standard/20057.html" }
+                ],
                 "terms" => [
                   {
                     "type" => "expression",
@@ -127,8 +132,11 @@ RSpec.describe Tc211::Termbase do
                 "entry_status" => "valid",
                 "review_date" => Time.parse("2013-01-29 00:00:00"),
                 "review_decision_date" => Time.parse("2016-10-01 00:00:00"),
-                "review_decision_event" => "Publication of ISO 19104:2016"
-              }
+                "review_decision_event" => "Publication of ISO 19104:2016",
+              },
+              "dateAccepted" => Time.parse("2008-11-15"),
+              "id" => "e59bc5ef-54aa-5d99-bf52-de87ea129979",
+              "status" => "valid"
             }
           end
 

--- a/spec/tc211/termbase_spec.rb
+++ b/spec/tc211/termbase_spec.rb
@@ -1,5 +1,3 @@
-require "pry"
-
 RSpec.describe Tc211::Termbase do
   it "has a version number" do
     expect(Tc211::Termbase::VERSION).not_to be nil
@@ -105,7 +103,7 @@ RSpec.describe Tc211::Termbase do
                     "origin" => {
                       "ref" => "ISO 1087-1:2000",
                       "clause" => "3.4.9",
-                      "link" => "https://www.iso.org/standard/20057.html"
+                      "link" => "https://www.iso.org/standard/20057.html",
                     },
                     "type" => "authoritative",
                     "status" => "identical",
@@ -119,7 +117,7 @@ RSpec.describe Tc211::Termbase do
                   },
                 ],
                 "authoritativeSource" => [
-                  { "link"=>"https://www.iso.org/standard/20057.html" }
+                  { "link" => "https://www.iso.org/standard/20057.html" },
                 ],
                 "terms" => [
                   {
@@ -136,7 +134,7 @@ RSpec.describe Tc211::Termbase do
               },
               "dateAccepted" => Time.parse("2008-11-15"),
               "id" => "e59bc5ef-54aa-5d99-bf52-de87ea129979",
-              "status" => "valid"
+              "status" => "valid",
             }
           end
 

--- a/spec/tc211/termbase_spec.rb
+++ b/spec/tc211/termbase_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Tc211::Termbase do
                 "review_decision_event" => "Publication of ISO 19104:2016",
               },
               "dateAccepted" => Time.parse("2008-11-15"),
-              "id" => "e59bc5ef-54aa-5d99-bf52-de87ea129979",
+              "id" => localized_concept.uuid,
               "status" => "valid",
             }
           end


### PR DESCRIPTION
Using custom `concept` and `managed_concept` models to add register info to generated concepts.