### PR TITLE
fix: replace wrong ISO 639-2 codes: "ger" => "deu", "chi" => "zho"

### DIFF
--- a/lib/tc211/termbase/terminology_sheet.rb
+++ b/lib/tc211/termbase/terminology_sheet.rb
@@ -30,6 +30,11 @@ module Tc211::Termbase
       @language_code = case code
       when "dut/nld"
         "dut"
+      when "chi"
+        "zho"
+      when "ger"
+        "deu"
+      # below for backwards compatibility
       when "工作语言代码"
         "chn"
       when "pl"

--- a/lib/tc211/termbase/terminology_sheet.rb
+++ b/lib/tc211/termbase/terminology_sheet.rb
@@ -29,7 +29,7 @@ module Tc211::Termbase
 
       @language_code = case code
       when "dut/nld"
-        "dut"
+        "nld"
       when "chi"
         "zho"
       when "ger"


### PR DESCRIPTION
Fixes #35.