### PR TITLE
Adding status valid when missing in file

### DIFF
--- a/lib/tc211/termbase/glossarist/concept.rb
+++ b/lib/tc211/termbase/glossarist/concept.rb
@@ -24,7 +24,7 @@ module Tc211
           {
             "dateAccepted" => date_accepted&.date&.dup,
             "id" => uuid,
-            "status" => entry_status,
+            "status" => entry_status || "valid",
           }.compact
         end
       end

--- a/spec/tc211/termbase_spec.rb
+++ b/spec/tc211/termbase_spec.rb
@@ -162,6 +162,22 @@ RSpec.describe Tc211::Termbase do
           end
         end
       end
+
+      context "concept 18" do
+        let(:concept) { collection.fetch("18") }
+
+        it "should have 11 localized concepts" do
+          expect(concept.localized_concepts.count).to be(11)
+        end
+
+        context "dan localization with status missing in file" do
+          let(:localized_concept) { concept.localization("dan") }
+
+          it "should have status=valid" do
+            expect(localized_concept.status).to eq("valid")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
As discussed in https://github.com/geolexica/isotc211-glossary/issues/49#issuecomment-2107529596, Adding `status: valid` to concepts if the `status` column is missing in file.